### PR TITLE
Blockchain: Add WBERA to token list

### DIFF
--- a/tokenLists/blockchain_testnet.json
+++ b/tokenLists/blockchain_testnet.json
@@ -58,7 +58,7 @@
   ],
   "version": {
     "major": 3,
-    "minor": 0,
+    "minor": 1,
     "patch": 0
   }
 }

--- a/tokenLists/blockchain_testnet.json
+++ b/tokenLists/blockchain_testnet.json
@@ -39,6 +39,15 @@
     },
     {
       "chainId": 6231991,
+      "address": "0xeda89b957E6cC0f15aB27307A386370814629FEe",
+      "symbol": "WBERA",
+      "name": "Wrapped Bera",
+      "decimals": 18,
+      "logoURI": "https://static.kodiak.finance/tokens/wbera.png",
+      "tags": []
+    },
+    {
+      "chainId": 6231991,
       "address": "0x1E9cc7764D7974D2F15f6B4AD3DD1f2e47892fBF",
       "symbol": "WETH",
       "name": "Wrapped Ether",


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces a new token entry in the `tokenLists/blockchain_testnet.json` file and updates the version number.

### Detailed summary
- Added a new token with the following details:
  - `chainId`: 6231991
  - `address`: `0xeda89b957E6cC0f15aB27307A386370814629FEe`
  - `symbol`: `WBERA`
  - `name`: `Wrapped Bera`
  - `decimals`: 18
  - `logoURI`: `https://static.kodiak.finance/tokens/wbera.png`
- Updated `minor` version from 0 to 1.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->