### PR TITLE
Add cPOLLEN to mainnet

### DIFF
--- a/tokenLists/berachain_mainnet.json
+++ b/tokenLists/berachain_mainnet.json
@@ -95,7 +95,7 @@
   ,{"chainId": 80094, "address": "0xff0a636dfc44bb0129b631cdd38d21b613290c98", "symbol": "HOLD", "name": "Holdstation", "decimals": 18, "logoURI": "https://static.kodiak.finance/tokens/holdstation.png", "tags": []}
   ,{"chainId": 80094, "address": "0x231A6BD8eB88Cfa42776B7Ac575CeCAf82bf1E21", "symbol": "PLUG", "name": "Beraplug", "decimals": 18, "logoURI": "https://static.kodiak.finance/tokens/plug.png", "tags": ["meme"]}
   ,{"chainId": 80094, "address": "0x6FF4D64976428025Cdcc3354EF53b5D19637481e", "symbol": "ARTIO", "name": "Artio", "decimals": 18, "logoURI": "https://static.kodiak.finance/tokens/artio.png", "tags": ["meme"]}
-  ,{"chainId": 80094, "address": "0x8E06ba13C03104f0C78A435C6FA0C0C33aE159d1", "symbol": "cPOLLEN", "name": "Pollen points", "decimals": 18, "logoURI": "https://static.kodiak.finance/tokens/cpollen.png", "tags": ["eco"]}
+  ,{"chainId": 80094, "address": "0x42cF42e55c89C6389FbbBA27dAeD4E6d2908ECF9", "symbol": "cPOLLEN", "name": "Pollen points", "decimals": 18, "logoURI": "https://static.kodiak.finance/tokens/cpollen.png", "tags": ["eco"]}
   ,{"chainId": 80094, "address": "0xA452810A4215fCCC834ED241e6667f519b9856EC", "symbol": "BBOT", "name": "Berabot", "decimals": 18, "logoURI": "https://static.kodiak.finance/tokens/berabot.png", "tags": ["eco"]}
   ,{"chainId": 80094, "address": "0x688e72142674041f8f6Af4c808a4045cA1D6aC82", "symbol": "BYUSD", "name": "BYUSD", "decimals": 6, "logoURI": "https://static.kodiak.finance/tokens/byusd.png", "tags": ["usd"]}
   ,{"chainId": 80094, "address": "0x047b41A14F0BeF681b94f570479AE7208E577a0C", "symbol": "HIM", "name": "Honey is Money", "decimals": 18, "logoURI": "https://static.kodiak.finance/tokens/him.png", "tags": ["meme"]}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the `tokenLists/berachain_mainnet.json` file by replacing an existing token entry for `cPOLLEN` with a new address while also retaining the other token information.

### Detailed summary
- Removed the old `cPOLLEN` entry with address `0x8E06ba13C03104f0C78A435C6FA0C0C33aE159d1`.
- Added a new `cPOLLEN` entry with address `0x42cF42e55c89C6389FbbBA27dAeD4E6d2908ECF9`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->